### PR TITLE
Add support for Specifying the Type of document

### DIFF
--- a/edinet_xbrl/edinet_data_util.py
+++ b/edinet_xbrl/edinet_data_util.py
@@ -12,53 +12,53 @@
 
 
 class EdinetDataUtil(object):
-  CONTEXT_REF = "contextref"
-  UNIT_REF = "unitref"
-  DECIMALS = "decimals" 
-  FORMAT = "format"
-  NAME = "name"
-  SCALE = "scale"
+    CONTEXT_REF = "contextref"
+    UNIT_REF = "unitref"
+    DECIMALS = "decimals"
+    FORMAT = "format"
+    NAME = "name"
+    SCALE = "scale"
 
-  @staticmethod
-  def get_key(node):
-    return node.name
+    @staticmethod
+    def get_key(node):
+        return node.name
 
-  @staticmethod
-  def get_value(node):
-    return node.string
+    @staticmethod
+    def get_value(node):
+        return node.string
 
-  @staticmethod
-  def offset(num, power):
-    return num * pow(10, power)
+    @staticmethod
+    def offset(num, power):
+        return num * pow(10, power)
 
-  @staticmethod
-  def _get_ref_str_value(node, key):
-    return node.attrs.get(key, "")
+    @staticmethod
+    def _get_ref_str_value(node, key):
+        return node.attrs.get(key, "")
 
-  @staticmethod
-  def _get_ref_int_value(node, key):
-    return int(node.attrs.get(key, 0))
+    @staticmethod
+    def _get_ref_int_value(node, key):
+        return int(node.attrs.get(key, 0))
 
-  @classmethod
-  def get_context_ref(cls, node):
-    return cls._get_ref_str_value(node, cls.CONTEXT_REF)
+    @classmethod
+    def get_context_ref(cls, node):
+        return cls._get_ref_str_value(node, cls.CONTEXT_REF)
 
-  @classmethod
-  def get_unit_ref(cls, node):
-    return cls._get_ref_str_value(node, cls.UNIT_REF)
+    @classmethod
+    def get_unit_ref(cls, node):
+        return cls._get_ref_str_value(node, cls.UNIT_REF)
 
-  @classmethod
-  def get_decimals(cls, node):
-    return cls._get_ref_int_value(node, cls.DECIMALS)
+    @classmethod
+    def get_decimals(cls, node):
+        return cls._get_ref_int_value(node, cls.DECIMALS)
 
-  @classmethod
-  def get_format(cls, node):
-    return cls._get_ref_str_value(node, cls.FORMAT)
+    @classmethod
+    def get_format(cls, node):
+        return cls._get_ref_str_value(node, cls.FORMAT)
 
-  @classmethod
-  def get_name(cls, node):
-    return cls._get_ref_str_value(node, cls.NAME)
+    @classmethod
+    def get_name(cls, node):
+        return cls._get_ref_str_value(node, cls.NAME)
 
-  @classmethod
-  def get_scale(cls, node):
-    return cls._get_ref_int_value(node, cls.SCALE)
+    @classmethod
+    def get_scale(cls, node):
+        return cls._get_ref_int_value(node, cls.SCALE)

--- a/edinet_xbrl/edinet_xbrl_downloader.py
+++ b/edinet_xbrl/edinet_xbrl_downloader.py
@@ -18,19 +18,23 @@ import urllib.request
 
 class EdinetXbrlDownloader(object):
     @classmethod
-    def download(cls, url, target_dir, is_override):
+    def download(cls, url, target_dir, is_override, is_numbering):
         file_name = "{0}/{1}".format(target_dir, url.split("/")[-1])
-        if os.path.exists(file_name) and not is_override:
-            file_name = cls.__get_next_file_name(file_name)
+        if os.path.exists(file_name):
+            if not is_override:
+                return
+            if is_numbering:
+                file_name = cls.__get_next_file_name(file_name)
         urllib.request.urlretrieve(url, file_name)
 
     @classmethod
-    def download_by_ticker(cls, ticker, target_dir, wait_sec=1.0, type_of_document="", is_override=True):
+    def download_by_ticker(cls, ticker, target_dir, wait_sec=1.0, type_of_document="",
+                           is_override=True, is_numbering=False):
         response = UfoCatcherUtil.request(ticker)
         for url in UfoCatcherUtil.generate_edinet_xbrl_url(response.text):
             if not cls.__is_type_of_document(url, type_of_document):
                 continue
-            cls.download(url, target_dir, is_override)
+            cls.download(url, target_dir, is_override, is_numbering)
             sleep(wait_sec)
 
     @staticmethod

--- a/edinet_xbrl/edinet_xbrl_downloader.py
+++ b/edinet_xbrl/edinet_xbrl_downloader.py
@@ -10,6 +10,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License. See accompanying LICENSE file.
 
+import os
 from edinet_xbrl.ufocatcher_util import UfoCatcherUtil
 from time import sleep
 import urllib.request
@@ -19,11 +20,14 @@ class EdinetXbrlDownloader(object):
   @staticmethod
   def download(url, target_dir):
     file_name = "{0}/{1}".format(target_dir, url.split("/")[-1])
-    urllib.request.urlretrieve(url, file_name)
+    if not os.path.exists(file_name):
+        urllib.request.urlretrieve(url, file_name)
+        return True
+    return False
 
   @classmethod
   def download_by_ticker(cls, ticker, target_dir, wait_sec=1.0):
     response = UfoCatcherUtil.request(ticker)
     for url in UfoCatcherUtil.generate_edinet_xbrl_url(response.text):
-      cls.download(url, target_dir)
-      sleep(wait_sec)
+        if cls.download(url, target_dir):
+              sleep(wait_sec)

--- a/edinet_xbrl/edinet_xbrl_downloader.py
+++ b/edinet_xbrl/edinet_xbrl_downloader.py
@@ -17,17 +17,17 @@ import urllib.request
 
 
 class EdinetXbrlDownloader(object):
-  @staticmethod
-  def download(url, target_dir):
-    file_name = "{0}/{1}".format(target_dir, url.split("/")[-1])
-    if not os.path.exists(file_name):
-        urllib.request.urlretrieve(url, file_name)
-        return True
-    return False
+    @staticmethod
+    def download(url, target_dir):
+        file_name = "{0}/{1}".format(target_dir, url.split("/")[-1])
+        if not os.path.exists(file_name):
+            urllib.request.urlretrieve(url, file_name)
+            return True
+        return False
 
-  @classmethod
-  def download_by_ticker(cls, ticker, target_dir, wait_sec=1.0):
-    response = UfoCatcherUtil.request(ticker)
-    for url in UfoCatcherUtil.generate_edinet_xbrl_url(response.text):
-        if cls.download(url, target_dir):
-              sleep(wait_sec)
+    @classmethod
+    def download_by_ticker(cls, ticker, target_dir, wait_sec=1.0):
+        response = UfoCatcherUtil.request(ticker)
+        for url in UfoCatcherUtil.generate_edinet_xbrl_url(response.text):
+            if cls.download(url, target_dir):
+                sleep(wait_sec)

--- a/edinet_xbrl/edinet_xbrl_downloader.py
+++ b/edinet_xbrl/edinet_xbrl_downloader.py
@@ -26,8 +26,20 @@ class EdinetXbrlDownloader(object):
         return False
 
     @classmethod
-    def download_by_ticker(cls, ticker, target_dir, wait_sec=1.0):
+    def download_by_ticker(cls, ticker, target_dir, wait_sec=1.0, type_of_document=""):
         response = UfoCatcherUtil.request(ticker)
         for url in UfoCatcherUtil.generate_edinet_xbrl_url(response.text):
+            if not cls.__is_type_of_document(url, type_of_document):
+                continue
             if cls.download(url, target_dir):
                 sleep(wait_sec)
+
+    @staticmethod
+    def __is_type_of_document(url, type_of_document):
+        """
+        Specify the Type of document of url
+        If you don't want to specify the type of document -> type_of_document = ""
+        """
+        if type_of_document == "":
+            return True
+        return type_of_document in url.split('-')

--- a/edinet_xbrl/edinet_xbrl_object.py
+++ b/edinet_xbrl/edinet_xbrl_object.py
@@ -15,66 +15,66 @@ from edinet_xbrl.edinet_data_util import EdinetDataUtil
 
 
 class EdinetData(object):
-  def __init__(self, key, value, decimals=0, unit_ref="", context_ref=""):
-    self.key = key
-    self.value = value
-    self.decimals = decimals
-    self.unit_ref = unit_ref
-    self.context_ref = context_ref
+    def __init__(self, key, value, decimals=0, unit_ref="", context_ref=""):
+        self.key = key
+        self.value = value
+        self.decimals = decimals
+        self.unit_ref = unit_ref
+        self.context_ref = context_ref
 
-  def get_key(self):
-    return self.key
+    def get_key(self):
+        return self.key
 
-  def get_value(self):
-    return self.value
+    def get_value(self):
+        return self.value
 
-  def get_decimals(self):
-    return self.decimals
+    def get_decimals(self):
+        return self.decimals
 
-  def get_unit_ref(self):
-    return self.unit_ref
+    def get_unit_ref(self):
+        return self.unit_ref
 
-  def get_context_ref(self):
-    return self.context_ref
+    def get_context_ref(self):
+        return self.context_ref
 
-  @staticmethod
-  def create(node):
-    key = EdinetDataUtil.get_key(node)
-    value = EdinetDataUtil.get_value(node)
-    decimals = EdinetDataUtil.get_decimals(node)
-    unit_ref = EdinetDataUtil.get_unit_ref(node)
-    context_ref = EdinetDataUtil.get_context_ref(node)
-    return EdinetData(key, value, decimals, unit_ref, context_ref)
+    @staticmethod
+    def create(node):
+        key = EdinetDataUtil.get_key(node)
+        value = EdinetDataUtil.get_value(node)
+        decimals = EdinetDataUtil.get_decimals(node)
+        unit_ref = EdinetDataUtil.get_unit_ref(node)
+        context_ref = EdinetDataUtil.get_context_ref(node)
+        return EdinetData(key, value, decimals, unit_ref, context_ref)
 
 
 class EdinetXbrlObject(object):
-  def __init__(self):
-    self._data_dict = OrderedDict()
+    def __init__(self):
+        self._data_dict = OrderedDict()
 
-  def clear(self):
-    self._data_dict.clear()
+    def clear(self):
+        self._data_dict.clear()
 
-  def put(self, key, edinet_data):
-    if self.has_key(key):
-      self._data_dict[key].append(edinet_data)
-    else:
-      self._data_dict[key] = [edinet_data]
+    def put(self, key, edinet_data):
+        if self.has_key(key):
+            self._data_dict[key].append(edinet_data)
+        else:
+            self._data_dict[key] = [edinet_data]
 
-  def get_data_list(self, key, auto_lower=True):
-    if auto_lower:
-      key = key.lower()
+    def get_data_list(self, key, auto_lower=True):
+        if auto_lower:
+            key = key.lower()
 
-    return self._data_dict.get(key, [])
+        return self._data_dict.get(key, [])
 
-  def get_data_by_context_ref(self, key, context_ref):
-    val = list(filter(lambda d: d.get_context_ref() == context_ref, self.get_data_list(key)))
-    if val:
-      return val[0]
-    else:
-      return None
+    def get_data_by_context_ref(self, key, context_ref):
+        val = list(filter(lambda d: d.get_context_ref() == context_ref, self.get_data_list(key)))
+        if val:
+            return val[0]
+        else:
+            return None
 
-  def get_keys(self):
-    return self._data_dict.keys()
+    def get_keys(self):
+        return self._data_dict.keys()
 
-  def has_key(self, key):
-    return (key in self._data_dict)
+    def has_key(self, key):
+        return key in self._data_dict

--- a/edinet_xbrl/edinet_xbrl_parser.py
+++ b/edinet_xbrl/edinet_xbrl_parser.py
@@ -14,17 +14,17 @@ from xbrl import XBRLParser
 from edinet_xbrl.edinet_xbrl_object import EdinetData, EdinetXbrlObject
 import codecs
 
+
 class EdinetXbrlParser(object):
-  @classmethod
-  def parse_file(cls, xbrl_file_path):
-    data_container = EdinetXbrlObject()
-    with codecs.open(xbrl_file_path, 'r', 'utf-8') as of:
-      parser = XBRLParser.parse(of)
-      for node in parser.find_all():
-        cls.put_node(data_container, node)
-    return data_container
+    @classmethod
+    def parse_file(cls, xbrl_file_path):
+        data_container = EdinetXbrlObject()
+        with codecs.open(xbrl_file_path, 'r', 'utf-8') as of:
+            parser = XBRLParser.parse(of)
+            for node in parser.find_all():
+                cls.put_node(data_container, node)
+        return data_container
 
-  @staticmethod
-  def put_node(data_container, node):
-    data_container.put(node.name, EdinetData.create(node))
-
+    @staticmethod
+    def put_node(data_container, node):
+        data_container.put(node.name, EdinetData.create(node))

--- a/edinet_xbrl/ufocatcher_util.py
+++ b/edinet_xbrl/ufocatcher_util.py
@@ -15,37 +15,39 @@ import requests
 
 
 class UfoCatcherUtil(object):
-  NAMESPACE = '{http://www.w3.org/2005/Atom}'
-  FAKE_HTTP_HEADER = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36))"}
-  UFOCATCH_URL = 'http://resource.ufocatch.com/atom/edinetx/query'
+    NAMESPACE = '{http://www.w3.org/2005/Atom}'
+    FAKE_HTTP_HEADER = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) "
+                      "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36))"}
+    UFOCATCH_URL = 'http://resource.ufocatch.com/atom/edinetx/query'
 
-  @classmethod
-  def create_url(cls, query):
-    return "{0}/{1}".format(cls.UFOCATCH_URL, query)
+    @classmethod
+    def create_url(cls, query):
+        return "{0}/{1}".format(cls.UFOCATCH_URL, query)
 
-  @classmethod
-  def request(cls, tikcer, headers=FAKE_HTTP_HEADER):
-    return requests.get(url=cls.create_url(tikcer), headers=headers)
+    @classmethod
+    def request(cls, tikcer, headers=FAKE_HTTP_HEADER):
+        return requests.get(url=cls.create_url(tikcer), headers=headers)
 
-  @classmethod
-  def is_edinet_xbrl_url(cls, element):
-    url = cls.get_href_attrib(element)
-    return False if url is None else ("PublicDoc" in url and url.endswith(".xbrl"))
+    @classmethod
+    def is_edinet_xbrl_url(cls, element):
+        url = cls.get_href_attrib(element)
+        return False if url is None else ("PublicDoc" in url and url.endswith(".xbrl"))
 
-  @classmethod
-  def get_et_tree(cls, html):
-    et_tree = ET.fromstring(html)
-    ET.register_namespace('', cls.NAMESPACE[1:-1])
-    return et_tree
+    @classmethod
+    def get_et_tree(cls, html):
+        et_tree = ET.fromstring(html)
+        ET.register_namespace('', cls.NAMESPACE[1:-1])
+        return et_tree
 
-  @classmethod
-  def generate_edinet_xbrl_url(cls, html):
-    et_tree = cls.get_et_tree(html)
-    for el in et_tree.findall('.//' + cls.NAMESPACE + 'entry'):
-      for link in el.findall('./' + cls.NAMESPACE +'link[@type="text/xml"]'):
-        if cls.is_edinet_xbrl_url(link):
-          yield cls.get_href_attrib(link)
+    @classmethod
+    def generate_edinet_xbrl_url(cls, html):
+        et_tree = cls.get_et_tree(html)
+        for el in et_tree.findall('.//' + cls.NAMESPACE + 'entry'):
+            for link in el.findall('./' + cls.NAMESPACE + 'link[@type="text/xml"]'):
+                if cls.is_edinet_xbrl_url(link):
+                    yield cls.get_href_attrib(link)
 
-  @staticmethod
-  def get_href_attrib(element):
-    return element.attrib.get('href', None)
+    @staticmethod
+    def get_href_attrib(element):
+        return element.attrib.get('href', None)

--- a/tests/edinet_xbrl_parser_test.py
+++ b/tests/edinet_xbrl_parser_test.py
@@ -20,50 +20,62 @@ import codecs
 
 
 class EdinetXbrlParserTestCase(unittest.TestCase):
-  TEST_DIR = "{0}/test_data".format(os.path.dirname(os.path.abspath(__file__)))
-  EMPLOYEES_NUM_KEY = "jpcrp_cor:NumberOfEmployees"
-  ASSETS_NUM_KEY = "jppfs_cor:Assets"
-  NETSALES_KEY = "jppfs_cor:NetSales"
-  CURRENT_YEAR_INSTANT_CONTEXT =  "CurrentYearInstant"
-  CURRENT_YEAR_DURATION_CONTEXT =  "CurrentYearDuration"
-  CURRENT_YEAR_INSTANT_NON_CON_CONTEXT = "CurrentYearInstant_NonConsolidatedMember"
-  CURRENT_YEAR_DURATION_NON_CON_CONTEXT =  "CurrentYearDuration_NonConsolidatedMember"
+    TEST_DIR = "{0}/test_data".format(os.path.dirname(os.path.abspath(__file__)))
+    EMPLOYEES_NUM_KEY = "jpcrp_cor:NumberOfEmployees"
+    ASSETS_NUM_KEY = "jppfs_cor:Assets"
+    NETSALES_KEY = "jppfs_cor:NetSales"
+    CURRENT_YEAR_INSTANT_CONTEXT = "CurrentYearInstant"
+    CURRENT_YEAR_DURATION_CONTEXT = "CurrentYearDuration"
+    CURRENT_YEAR_INSTANT_NON_CON_CONTEXT = "CurrentYearInstant_NonConsolidatedMember"
+    CURRENT_YEAR_DURATION_NON_CON_CONTEXT = "CurrentYearDuration_NonConsolidatedMember"
 
-  @staticmethod
-  def parse(xbrl_file_path):
-    parser = EdinetXbrlParser()
-    return parser.parse_file(xbrl_file_path)
+    @staticmethod
+    def parse(xbrl_file_path):
+        parser = EdinetXbrlParser()
+        return parser.parse_file(xbrl_file_path)
 
-  @classmethod
-  def get_xbrl_file(cls, target):
-    return "{0}/{1}.xbrl".format(cls.TEST_DIR, target)
+    @classmethod
+    def get_xbrl_file(cls, target):
+        return "{0}/{1}.xbrl".format(cls.TEST_DIR, target)
 
-  @classmethod
-  def get_expected_dict(cls, target):
-    yaml_file = "{0}/{1}.yaml".format(cls.TEST_DIR, target)
-    with codecs.open(yaml_file, 'r', 'utf-8') as f:
-      return yaml.load(f)
+    @classmethod
+    def get_expected_dict(cls, target):
+        yaml_file = "{0}/{1}.yaml".format(cls.TEST_DIR, target)
+        with codecs.open(yaml_file, 'r', 'utf-8') as f:
+            return yaml.load(f)
 
-  @classmethod
-  def test_kakaku(cls):
-    target = "CJ_2371_kakakucom"
-    xbrl_file = cls.get_xbrl_file(target)
-    data_container = cls.parse(xbrl_file)
-    expected_dict = cls.get_expected_dict(target)
-    eq_(expected_dict["employees_num"], int(data_container.get_data_by_context_ref(cls.EMPLOYEES_NUM_KEY, cls.CURRENT_YEAR_INSTANT_CONTEXT).get_value()))
-    eq_(expected_dict["assets"], int(data_container.get_data_by_context_ref(cls.ASSETS_NUM_KEY, cls.CURRENT_YEAR_INSTANT_CONTEXT).get_value()))
-    eq_(expected_dict["netsales"], int(data_container.get_data_by_context_ref(cls.NETSALES_KEY, cls.CURRENT_YEAR_DURATION_CONTEXT).get_value()))
+    @classmethod
+    def test_kakaku(cls):
+        target = "CJ_2371_kakakucom"
+        xbrl_file = cls.get_xbrl_file(target)
+        data_container = cls.parse(xbrl_file)
+        expected_dict = cls.get_expected_dict(target)
+        eq_(expected_dict["employees_num"],
+            int(data_container.get_data_by_context_ref(cls.EMPLOYEES_NUM_KEY,
+                                                       cls.CURRENT_YEAR_INSTANT_CONTEXT).get_value()))
+        eq_(expected_dict["assets"],
+            int(data_container.get_data_by_context_ref(cls.ASSETS_NUM_KEY,
+                                                       cls.CURRENT_YEAR_INSTANT_CONTEXT).get_value()))
+        eq_(expected_dict["netsales"],
+            int(data_container.get_data_by_context_ref(cls.NETSALES_KEY,
+                                                       cls.CURRENT_YEAR_DURATION_CONTEXT).get_value()))
 
-  @classmethod
-  def test_yahoo(cls):
-    target = "CI_4689_yahoo"
-    xbrl_file = cls.get_xbrl_file(target)
-    data_container = cls.parse(xbrl_file)
-    expected_dict = cls.get_expected_dict(target)
-    eq_(expected_dict["employees_num"], int(data_container.get_data_by_context_ref(cls.EMPLOYEES_NUM_KEY, cls.CURRENT_YEAR_INSTANT_NON_CON_CONTEXT).get_value()))
-    eq_(expected_dict["assets"], int(data_container.get_data_by_context_ref(cls.ASSETS_NUM_KEY, cls.CURRENT_YEAR_INSTANT_NON_CON_CONTEXT).get_value()))
-    eq_(expected_dict["netsales"], int(data_container.get_data_by_context_ref(cls.NETSALES_KEY, cls.CURRENT_YEAR_DURATION_NON_CON_CONTEXT).get_value()))
+    @classmethod
+    def test_yahoo(cls):
+        target = "CI_4689_yahoo"
+        xbrl_file = cls.get_xbrl_file(target)
+        data_container = cls.parse(xbrl_file)
+        expected_dict = cls.get_expected_dict(target)
+        eq_(expected_dict["employees_num"],
+            int(data_container.get_data_by_context_ref(cls.EMPLOYEES_NUM_KEY,
+                                                       cls.CURRENT_YEAR_INSTANT_NON_CON_CONTEXT).get_value()))
+        eq_(expected_dict["assets"],
+            int(data_container.get_data_by_context_ref(cls.ASSETS_NUM_KEY,
+                                                       cls.CURRENT_YEAR_INSTANT_NON_CON_CONTEXT).get_value()))
+        eq_(expected_dict["netsales"],
+            int(data_container.get_data_by_context_ref(cls.NETSALES_KEY,
+                                                       cls.CURRENT_YEAR_DURATION_NON_CON_CONTEXT).get_value()))
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/tests/ufocatcher_util_test.py
+++ b/tests/ufocatcher_util_test.py
@@ -12,35 +12,36 @@
 
 
 import unittest
-from  xml.etree.ElementTree import Element
+from xml.etree.ElementTree import Element
 from nose.tools import eq_, assert_true, assert_false
 from edinet_xbrl.ufocatcher_util import UfoCatcherUtil
 
 
 class UfoCatcherUtilTest(unittest.TestCase):
-  @staticmethod
-  def test_create_url():
-    query = 'aaa'
-    eq_('http://resource.ufocatch.com/atom/edinetx/query/' + query, UfoCatcherUtil.create_url(query))
+    @staticmethod
+    def test_create_url():
+        query = 'aaa'
+        eq_('http://resource.ufocatch.com/atom/edinetx/query/' + query, UfoCatcherUtil.create_url(query))
 
-  @staticmethod
-  def test_is_edinet_xbrl_url():
-    # true
-    ok_element = Element("", {"href": "http://aaa.bbb/PublicDoc/ccc.xbrl"})
-    assert_true(UfoCatcherUtil.is_edinet_xbrl_url(ok_element))
+    @staticmethod
+    def test_is_edinet_xbrl_url():
+        # true
+        ok_element = Element("", {"href": "http://aaa.bbb/PublicDoc/ccc.xbrl"})
+        assert_true(UfoCatcherUtil.is_edinet_xbrl_url(ok_element))
 
-    # false
-    for ng_element in [Element("", {"href": "http://aaa.bbb/ccc.xbrl"}), Element("", {"href": "http://aaa.bbb/PublicDoc/ccc.html"})]:
-      assert_false(UfoCatcherUtil.is_edinet_xbrl_url(ng_element))
+        # false
+        for ng_element in [Element("", {"href": "http://aaa.bbb/ccc.xbrl"}),
+                           Element("", {"href": "http://aaa.bbb/PublicDoc/ccc.html"})]:
+            assert_false(UfoCatcherUtil.is_edinet_xbrl_url(ng_element))
 
-  @staticmethod
-  def test_get_href_attrib():
-    href = "http://aaa.bbb/PublicDoc/ccc.xbrl"
-    element = Element("", {"href": href})
-    eq_(href, UfoCatcherUtil.get_href_attrib(element))
-    # if href attrib is unset
-    eq_(None, UfoCatcherUtil.get_href_attrib(Element("")))
+    @staticmethod
+    def test_get_href_attrib():
+        href = "http://aaa.bbb/PublicDoc/ccc.xbrl"
+        element = Element("", {"href": href})
+        eq_(href, UfoCatcherUtil.get_href_attrib(element))
+        # if href attrib is unset
+        eq_(None, UfoCatcherUtil.get_href_attrib(Element("")))
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
- Download by specifying the type of document
  If download only '有価証券報告書':  
`xbrl_downloader.download_by_ticker(ticker, target_dir, type_of_document='asr')`
- Useful download
  If file has exists, You select 'override', 'adding number' or 'do not download'.
  - override -> default
  `xbrl_downloader.download_by_ticker(ticker, target_dir)`
  - adding number
  `xbrl_downloader.download_by_ticker(ticker, target_dir, is_numbering=True)`
  - do not download
  `xbrl_downloader.download_by_ticker(ticker, target_dir, is_override=False)`
- reformat for PEP8